### PR TITLE
Fix retrieval spelling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ disqus_shortname: Jirigesi
 owner:
   name:           Jiri Gesi
   avatar:         jirigesi2.png
-  bio:            Machine Learning | Retrival & Ranking researcher
+  bio:            Machine Learning | Retrieval & Ranking researcher
   email:          jirigesi@gmail.com
   # Social networking links are used in author-bio sidebar. Update and remove as you like.
   twitter: jirigesi

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ tags: [Jekyll, theme, responsive, blog, template]
 
 ---
 
-<span style="color: orange;">**We have openings for Applied Scientist Interns and full-time positions! Contact me if you're interested in working on LLM for retrival&ranking!**</span>
+<span style="color: orange;">**We have openings for Applied Scientist Interns and full-time positions! Contact me if you're interested in working on LLM for retrieval&ranking!**</span>
 
 ### About me 
 


### PR DESCRIPTION
## Summary
- correct retrieval spelling in Jekyll config
- fix retrieval typo on the index page

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684648ccb4b0832fa2c64b1262ce5a5c